### PR TITLE
fix typo: parseOtps -> parserOtps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ gulp.task('default', function () {
     gulp.src('./test/src.xml')
         .pipe(xml({
             // options to initialize an XML2JS PARSER
-            parseOpts: {
+            parserOpts: {
                 trim: true
             },
             // options to initialize an XML2JS BUILDER


### PR DESCRIPTION
README中的参数名称书写有误，将`parseOtps`改为`parserOtps`。